### PR TITLE
Prevent transitive commons-logging dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,11 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
         <version>${logback-classic.version}</version>
@@ -241,11 +246,23 @@
         <artifactId>unitils-core</artifactId>
         <version>${unitils.version}</version>
         <scope>test</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
         <version>${commons-beanutils.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.openpojo</groupId>


### PR DESCRIPTION
Relates to https://github.com/eclipse-pass/main/issues/240

* Ensure `maven-enforcer-plugin` checks pass by preventing a `commons-logging` transitive dependency